### PR TITLE
Add a patch request to send parameters as notes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 # Change Log
 
-The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
+The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
+
+## Unreleased
+
+### Added
+
+- Add the translation parameters as "Notes" in Loco.
 
 ## 0.2.0
 
@@ -15,5 +21,3 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ## 0.1.0
 
 Init release
-
-

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php-translation/common": "^0.2",
         "php-translation/symfony-storage": "^0.2",
         "symfony/translation": "^2.7 || ^3.0",
+        "symfony/yaml": "^2.7 || ^3.0",
         "friendsofapi/localise.biz": "^0.2"
     },
     "require-dev": {

--- a/src/Loco.php
+++ b/src/Loco.php
@@ -15,6 +15,7 @@ use FAPI\Localise\Exception\Domain\AssetConflictException;
 use FAPI\Localise\Exception\Domain\NotFoundException;
 use FAPI\Localise\LocoClient;
 use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Yaml\Yaml;
 use Translation\Common\Exception\StorageException;
 use Translation\Common\Model\Message;
 use Translation\Common\Storage;
@@ -99,6 +100,22 @@ class Loco implements Storage, TransferableStorage
                     $message->getTranslation()
                 );
             }
+        }
+
+        if (!empty($message->getMeta('parameters'))) {
+            // Pretty print the Meta field via YAML export
+            $dump = Yaml::dump(['parameters' => $message->getMeta('parameters')], 4, 5);
+            $dump = str_replace("     -\n", '', $dump);
+            $dump = str_replace('     ', "\xC2\xA0", $dump); // no break space
+
+            $this->client->asset()->patch(
+                $projectKey,
+                $message->getKey(),
+                null,
+                null,
+                null,
+                $dump
+            );
         }
     }
 


### PR DESCRIPTION
Depends on https://github.com/FriendsOfApi/localise.biz/pull/16

When creating new Assets, this PR adds the Message parameters to Loco via the Patch API. This is doing an extra API call only for messages with parameters saved.

We use Yaml Dump and some tweaks to get a nice string representation of the array.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/225704/26036076/55b4b63c-38d7-11e7-8da2-39764490e2f6.png)
