### PR TITLE
Only export translated strings,

### DIFF
--- a/src/Loco.php
+++ b/src/Loco.php
@@ -154,7 +154,7 @@ class Loco implements Storage, TransferableStorage
                     $projectKey,
                     $locale,
                     'xliff',
-                    ['format' => 'symfony']
+                    ['format' => 'symfony', 'status' => 'translated']
                 );
 
                 $catalogue->addCatalogue(XliffConverter::contentToCatalogue($data, $locale, $domain));


### PR DESCRIPTION
The MessageCatalouge will treat Locos untranslated messages as translated but empty