### PR TITLE
[FIX] Using the get method on the translation api requires a string instead of object

### DIFF
--- a/src/Loco.php
+++ b/src/Loco.php
@@ -55,10 +55,10 @@ class Loco implements Storage, TransferableStorage
      */
     public function get($locale, $domain, $key)
     {
-        $projectKey = $this->getProject($domain);
+        $project = $this->getProject($domain);
 
         try {
-            $translation = $this->client->translations()->get($projectKey, $key, $locale)->getTranslation();
+            $translation = $this->client->translations()->get($project->getApiKey(), $key, $locale)->getTranslation();
         } catch (\FAPI\Localise\Exception $e) {
             return null;
         }


### PR DESCRIPTION
Topic says it all.