### PR TITLE
Manage many domains in one project with tags

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/TranslationAdapterLocoExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/TranslationAdapterLocoExtension.php
@@ -34,27 +34,18 @@ class TranslationAdapterLocoExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $domainToProjectMap = [];
+        $projects = [];
         $globalIndexParameter = $config['index_parameter'];
-        foreach ($config['projects'] as $domain => $data) {
+        foreach ($config['projects'] as $name => $data) {
             if (empty($data['index_parameter'])) {
                 $data['index_parameter'] = $globalIndexParameter;
             }
 
             $projectDefinition = new Definition(LocoProject::class);
-            if (empty($data['domains'])) {
-                $projectDefinition
-                    ->addArgument($domain)
-                    ->addArgument($data);
-                $domainToProjectMap[$domain] = $projectDefinition;
-            } else {
-                foreach ($data['domains'] as $d) {
-                    $projectDefinition
-                        ->addArgument($d)
-                        ->addArgument($data);
-                    $domainToProjectMap[$d] = $projectDefinition;
-                }
-            }
+            $projectDefinition
+                ->addArgument($name)
+                ->addArgument($data);
+            $projects[] = $projectDefinition;
         }
 
         $requestBuilder = (new Definition(RequestBuilder::class))
@@ -77,6 +68,6 @@ class TranslationAdapterLocoExtension extends Extension
             ->setClass(Loco::class)
             ->setPublic(true)
             ->addArgument($apiDef)
-            ->addArgument($domainToProjectMap);
+            ->addArgument($projects);
     }
 }

--- a/src/Loco.php
+++ b/src/Loco.php
@@ -171,7 +171,7 @@ class Loco implements Storage, TransferableStorage
                     $params = [
                         'format' => 'symfony',
                         'status' => 'translated',
-                        'index' => $project->getIndexParameter()
+                        'index' => $project->getIndexParameter(),
                     ];
 
                     if ($project->isMultiDomain()) {

--- a/src/Model/LocoProject.php
+++ b/src/Model/LocoProject.php
@@ -32,6 +32,11 @@ final class LocoProject
     private $indexParameter;
 
     /**
+     * @var array
+     */
+    private $domains;
+
+    /**
      * @param string $name
      * @param array  $config
      */
@@ -40,6 +45,7 @@ final class LocoProject
         $this->name = $name;
         $this->apiKey = $config['api_key'] ?? null;
         $this->indexParameter = $config['index_parameter'] ?? null;
+        $this->domains = $config['domains'] ?? [];
     }
 
     /**
@@ -64,5 +70,31 @@ final class LocoProject
     public function getIndexParameter()
     {
         return $this->indexParameter;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDomains()
+    {
+        return $this->domains;
+    }
+
+    /**
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public function hasDomain(string $domain)
+    {
+        return in_array($domain, $this->domains);
+    }
+
+    /**
+     * @return bool Returning true means that domains are expected to be managed with tags.
+     */
+    public function isMultiDomain()
+    {
+        return !empty($this->domains);
     }
 }

--- a/src/Model/LocoProject.php
+++ b/src/Model/LocoProject.php
@@ -45,7 +45,7 @@ final class LocoProject
         $this->name = $name;
         $this->apiKey = $config['api_key'] ?? null;
         $this->indexParameter = $config['index_parameter'] ?? null;
-        $this->domains = $config['domains'] ?? [];
+        $this->domains = empty($config['domains']) ? [$name] : $config['domains'];
     }
 
     /**
@@ -95,6 +95,6 @@ final class LocoProject
      */
     public function isMultiDomain()
     {
-        return !empty($this->domains);
+        return count($this->domains) > 1;
     }
 }


### PR DESCRIPTION
It should fix https://github.com/php-translation/loco-adapter/issues/6 (works on a real project).

Note that I'm using the `domains` property only for projects which are configured with many domains, because we may want to make a difference between projects that should use tags, and those that are single domain (which then does not need tags).

However, I'm not very proud of the if/else stuff done here.
It would be cleaner if single-domain projects had tagged translations as well, but as I explained above, I would break the existing behaviour.