### PR TITLE
Reverting #27.

### DIFF
--- a/src/Loco.php
+++ b/src/Loco.php
@@ -171,7 +171,7 @@ class Loco implements Storage, TransferableStorage
                     $project->getApiKey(),
                     $locale,
                     'xliff',
-                    ['filter' => $domain, 'format' => 'symfony', 'status' => 'translated', 'index' => $project->getIndexParameter()]
+                    ['format' => 'symfony', 'status' => 'translated', 'index' => $project->getIndexParameter()]
                 );
 
                 $catalogue->addCatalogue(XliffConverter::contentToCatalogue($data, $locale, $domain));


### PR DESCRIPTION
If the translation keys has not been created with the correct tag this will fail to download all messages.

I think #27 could be redone in a more configurable way. But I have to revert it right now because it is a BC break. 

FYI @Gladhon 