### PR TITLE
Add symfony-bundle type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "php-translation/loco-adapter",
     "description": "Adapter for loco.",
+    "type": "symfony-bundle",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
To be able to install this package with Flex, it should have `symfony-bundle` as type in composer.json

Fixes https://github.com/php-translation/loco-adapter/issues/32