### PR TITLE
Add config for select or reject status

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,7 @@ translation_adapter_loco:
       api_key: 'foobar' 
     navigation:
       api_key: 'bazbar' 
+      status: '!untranslated,!rejected' # if you want filter on loco translations statuses. By default only 'translated' translations are pulled.
 ```
 
 If you just doing one project and have tags for all your translation domains you may use this configuration:

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -65,6 +65,7 @@ class Configuration implements ConfigurationInterface
             ->prototype('array')
             ->children()
                 ->scalarNode('api_key')->isRequired()->end()
+                ->scalarNode('status')->defaultValue('translated')->end()
                 ->scalarNode('index_parameter')
                     ->info('Index parameter sent to loco api for this particular domain (overrides global one). Specify whether file indexes translations by asset ID or source texts')
                     ->example('id')

--- a/src/Loco.php
+++ b/src/Loco.php
@@ -171,9 +171,12 @@ class Loco implements Storage, TransferableStorage
                 try {
                     $params = [
                         'format' => 'symfony',
-                        'status' => 'translated',
                         'index' => $project->getIndexParameter(),
                     ];
+
+                    if ($project->getStatus()) {
+                        $params['status'] = $project->getStatus();
+                    }
 
                     if ($project->isMultiDomain()) {
                         $params['filter'] = $domain;

--- a/src/Model/LocoProject.php
+++ b/src/Model/LocoProject.php
@@ -29,6 +29,11 @@ final class LocoProject
     /**
      * @var string
      */
+    private $status;
+
+    /**
+     * @var string
+     */
     private $indexParameter;
 
     /**
@@ -44,6 +49,7 @@ final class LocoProject
     {
         $this->name = $name;
         $this->apiKey = $config['api_key'] ?? null;
+        $this->status = $config['status'] ?? null;
         $this->indexParameter = $config['index_parameter'] ?? null;
         $this->domains = empty($config['domains']) ? [$name] : $config['domains'];
     }
@@ -62,6 +68,14 @@ final class LocoProject
     public function getApiKey()
     {
         return $this->apiKey;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStatus()
+    {
+        return $this->status;
     }
 
     /**

--- a/tests/Unit/Model/LocoProjectTest.php
+++ b/tests/Unit/Model/LocoProjectTest.php
@@ -23,7 +23,7 @@ class LocoProjectTest extends TestCase
 
     public function setUp()
     {
-        $this->locoProject = new LocoProject('domain', ['api_key' => 'test', 'index_parameter' => 'text']);
+        $this->locoProject = new LocoProject('domain', ['api_key' => 'test', 'status' => '!untranslated,!rejected', 'index_parameter' => 'text']);
     }
 
     public function testWithEmptyConfig()
@@ -41,6 +41,11 @@ class LocoProjectTest extends TestCase
     public function testGetApiKey()
     {
         $this->assertEquals('test', $this->locoProject->getApiKey());
+    }
+
+    public function testGetStatus()
+    {
+        $this->assertEquals('!untranslated,!rejected', $this->locoProject->getStatus());
     }
 
     public function testGetIndexParameter()


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Bug fix?      | no  |
| New feature?  | yes |
| Deprecations? | no  |

This pull request allows you to add a filter on Loco's different statuses.

This is interesting in case there are different environments. For example, in the development or demonstration phase the translations can be in a 'Provisional', 'Incomplete', ...  statuses. Therefore translations isn't translated, since they are not validated yet. This solution is flexible and allows any status from the configuration. 

Example in our project:
In Loco :

Translations added by developer and not validated yet:
![loco-provisional-translation](https://user-images.githubusercontent.com/17196187/67093817-b84c6d80-f1b2-11e9-99b7-dd3a1a9c822c.png)

then translations are validated:
![loco-translated-translation](https://user-images.githubusercontent.com/17196187/67093799-b4205000-f1b2-11e9-9935-ffdca9851c8f.png)

Here is an example configuration:

```yaml
translation_adapter_loco:
    projects:
        project_1:
            api_key: 'api_key'
        project_2:
            api_key: 'api_key'
            status: 'translated,provisional'
        project_3:
            api_key: 'api_key'
            status: '!untranslated,!rejected'
```

And here are the resulted calls to Loco api:

```
project 1:
https://localise.biz/api/export/locale/en.json?key=API_KEY&status=translated
project 2:
https://localise.biz/api/export/locale/en.json?key=API_KEY&status=translated,provisional
project 3:
https://localise.biz/api/export/locale/en.json?key=API_KEY&status=!untranslated,!rejected
```

Note that the status is optional and default value is the same as today: translated

This pull request also fixes this pull request https://github.com/php-translation/loco-adapter/pull/43