### PR TITLE
Adding format=symfony for imports

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ If you have one Loco project per domain you may configure the bundle like this:
 ```yaml
 # /app/config/config.yml
 translation_adapter_loco:
-  index_parameter: 'id' # 'text' or 'name'. Leave blank for "auto"  See https://localise.biz/api/docs/export/exportlocale
+  index_parameter: 'id' # recommended for Symfony XLIFF See https://localise.biz/help/formats/importing/xliff#symfony
   projects:
     messages:
       api_key: 'foobar'
@@ -43,7 +43,7 @@ If you just doing one project and have tags for all your translation domains you
 ```yaml
 # /app/config/config.yml
 translation_adapter_loco:
-  index_parameter: 'id' # 'text' or 'name'. Leave blank for "auto"  See https://localise.biz/api/docs/export/exportlocale
+  index_parameter: 'id' # recommended for Symfony XLIFF See https://localise.biz/help/formats/importing/xliff#symfony
   projects:
     acme:
       api_key: 'foobar'

--- a/src/Loco.php
+++ b/src/Loco.php
@@ -206,6 +206,7 @@ class Loco implements Storage, TransferableStorage
                     'locale' => $locale,
                     'async' => 1,
                     'index' => $project->getIndexParameter(),
+                    'format' => 'symfony',
                 ];
 
                 if ($project->isMultiDomain()) {


### PR DESCRIPTION
This is required for XLIFF 2.0 files produced by Symfony's `XliffFileDumper`. 

The `name` attribute is [only rendered when the translation key is 80 bytes or less](https://github.com/symfony/translation/blob/7.0/Dumper/XliffFileDumper.php#L172-L174). 

When absent, Loco's standard XLIFF parser would fall back to the `id` attribute in order to establish the unique translation key. The `format=symfony` parameter overrides this behaviour, ensuring that the key is  taken from the `<source>` element as per Symfony's use of XLIFF.
